### PR TITLE
fix(Casdoor): add OAuth2 state management and /login flow to Casdoor integration

### DIFF
--- a/examples/core-casdoor/README.md
+++ b/examples/core-casdoor/README.md
@@ -6,7 +6,8 @@ Full OAuth2 authentication and remote Casbin policy enforcement via
 ## What it demonstrates
 
 - `CasdoorIntegration` facade — one object wires the SDK, cookies, router, and guard
-- `GET /callback` — OAuth2 code exchange; issues `access_token` + `refresh_token` cookies
+- `GET /login` — issues OAuth2 state nonce and redirects to Casdoor
+- `GET /callback` — validates state, exchanges OAuth2 code for tokens, sets cookies
 - `POST /logout` — clears authentication cookies
 - `guard.require_permission(resource, action)` — delegates policy check to Casdoor's
   remote `/api/enforce` endpoint using the seeded ACL enforcer
@@ -50,16 +51,15 @@ uv run fastapi dev src/main.py --port 8080
 
 ### 3 — Try it (browser or curl)
 
-Open `http://localhost:8080/` to get the Casdoor login URL, then:
+Open `http://localhost:8080/login` in a browser to start the OAuth2 flow, then:
 
 ```bash
-# ── Step 1: get the login URL ────────────────────────────────────────────────
-curl -s http://localhost:8080/ | python3 -m json.tool
-
-# The response contains "login_url" — open it in a browser.
+# ── Step 1: open the login URL in a browser ───────────────────────────────────
+# Navigate to http://localhost:8080/login
+# The app issues a state nonce and redirects to Casdoor automatically.
 # Log in as alice / alice123.
-# Casdoor redirects to http://localhost:8080/callback?code=...
-# The app exchanges the code for tokens and sets cookies.
+# Casdoor redirects to http://localhost:8080/callback?code=...&state=...
+# The app validates the state and exchanges the code for tokens, then sets cookies.
 
 # ── Step 2: copy the cookies from the browser and use them below ─────────────
 ACCESS=<paste access_token cookie value>
@@ -92,8 +92,9 @@ curl -s -X POST http://localhost:8080/logout \
 
 | Method | Path | Auth | Permission | Description |
 |---|---|---|---|---|
-| `GET` | `/` | public | — | Returns Casdoor login URL |
-| `GET` | `/callback` | public | — | OAuth2 callback; sets cookies |
+| `GET` | `/` | public | — | Welcome message with link to `/login` |
+| `GET` | `/login` | public | — | Issues state nonce, redirects to Casdoor |
+| `GET` | `/callback` | public | — | Validates state, exchanges code, sets cookies |
 | `POST` | `/logout` | public | — | Clears cookies |
 | `GET` | `/me` | required | — | Returns decoded JWT payload |
 | `GET` | `/articles` | required | `articles:read` | List articles |
@@ -140,6 +141,6 @@ Casdoor upserts the data on startup (existing records are updated, new ones crea
 |---|---|---|
 | `401 Invalid token` | Wrong certificate in `authz.py` | Must match `cert-example` in `init_data.json` |
 | `403 Forbidden` for alice | Enforcer not loaded yet | Restart Casdoor; check permissions in admin panel |
-| `404` on `/callback` | Router not included | `app.include_router(casdoor.router)` |
+| `404` on `/login` or `/callback` | Router not included | `app.include_router(casdoor.router)` |
 | Login page shows wrong app | Wrong `org_name` / `app_name` | Must match `example-org` / `app-example` |
 | Casdoor not ready | MySQL still initialising | Wait 20 s, retry `curl http://localhost:8000/` |

--- a/examples/core-casdoor/casdoor/init_data.json
+++ b/examples/core-casdoor/casdoor/init_data.json
@@ -13,74 +13,20 @@
       "enableSoftDeletion": false
     }
   ],
-
-  "certs": [
-    {
-      "owner": "admin",
-      "name": "cert-example",
-      "displayName": "Example Certificate",
-      "scope": "JWT",
-      "type": "x509",
-      "cryptoAlgorithm": "RS256",
-      "bitSize": 2048,
-      "expireInYears": 10,
-      "certificate": "-----BEGIN CERTIFICATE-----\nMIIC2DCCAcCgAwIBAgIUdehFSHCw9b3QUw7Kg+UfTADcEQEwDQYJKoZIhvcNAQEL\nBQAwJjEkMCIGA1UEAwwbQ2FzZG9vciBFeGFtcGxlIENlcnRpZmljYXRlMB4XDTI2\nMDIyNzAzMDQ0M1oXDTM2MDIyNTAzMDQ0M1owJjEkMCIGA1UEAwwbQ2FzZG9vciBF\neGFtcGxlIENlcnRpZmljYXRlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC\nAQEAsG1LaxcbNp17HhFLyj0Byt9xFp5kFi/YIrzIpei+PIXCcSVAbGGy9yM18Liv\nJNygXDErYS8+qZOZr047o/8HCTQBcw8vuAOZL5TFLSqYBJMbPmRmwnNxnVs37/17\nuVh80kjeunzfgXtIYIbzm67Dwo5Qp64mBoFpoyzPbcoKGSaBbrh+yjHtevokWu2s\nx48qweDZwKKhxz2nFU76Zcm9KUh/Wj7w3kDqWfFTzSfGCUWePudkoVddpwin9clz\ntGgIf/b5L9seWJVwFX0SdDoPjiT0nkGtgXGkwqROvMLw4XI7MPmQnERmPpZxbS95\n7o7tnckVxvca83mF2YBY0B3mSwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCUPK4D\n+u9uT/AtrHftJbuDo8ITRg+URNC9CRefghtRMM5oZy8FWBVxAE9So8eSZ6myIJQJ\ntQDzth9OO7u6bScCUjNh/lkLhMCVqbC2J9qXODQs6mR+A5BKMnQDD/gaxkzFEjPb\n6o6F5SchtaeOikCYngvJP2/f5E9QS5QZ9wN7zG/u7JlqWdNM9OuyASqQPGsQJ5W4\nwbNjVtrDLli2a4TnrH2Wl584BWuoT5ENZlpv7aHuA+LZVKLrMJ0BciyaRdfStkEj\n1gqHjx6e6gQo9vTC445XxskxPgPppTP+hoGhI5tmz7jVpYqxwlUteb8zcXsrAF+d\nQcFAyxahEu3iZGWD\n-----END CERTIFICATE-----\n",
-      "privateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEAsG1LaxcbNp17HhFLyj0Byt9xFp5kFi/YIrzIpei+PIXCcSVA\nbGGy9yM18LivJNygXDErYS8+qZOZr047o/8HCTQBcw8vuAOZL5TFLSqYBJMbPmRm\nwnNxnVs37/17uVh80kjeunzfgXtIYIbzm67Dwo5Qp64mBoFpoyzPbcoKGSaBbrh+\nyjHtevokWu2sx48qweDZwKKhxz2nFU76Zcm9KUh/Wj7w3kDqWfFTzSfGCUWePudk\noVddpwin9clztGgIf/b5L9seWJVwFX0SdDoPjiT0nkGtgXGkwqROvMLw4XI7MPmQ\nnERmPpZxbS957o7tnckVxvca83mF2YBY0B3mSwIDAQABAoIBAEQikYPUMqBPBWNB\nTsHV+cE9tdEEbqba51/TBLJ+RindhpBn0I+K07D6GjTTPmDAC/ZOzvADbPHUnP/E\n+OeG8FKvkPe8n7MzQI/NprCgyIDLxzO7Vqw2JWSd++ZlQMj90YbsuYfP/gllcThG\nJgKz5cpXZ/K6INlWVVO9VIaUBn5bachAtE9YxjeEioY8vwanYOqYSQohlvBdp5su\nhFMS7U1bkjnvFDhAsRKQB7aomSlO0/FlOyw9ygKo0ZvKVf0q7flfB6BckFe+hOhs\nSfOPnMJzw4rm2Q0PoHZHP1m4H+UOXYygynlVlh1nkjfiiMmXG67ojcAAmQWxjb9h\n2bWKQAECgYEA6EgbyC14W/R/XiHk8NlbnYxfv9+ilUw+wo+URNm9lgANB095d6aF\ndOGGXwjcXyCF1Z0SxtggUhJh8Hj9sLp1cuC3qnWkRxvQKBmMirzppB3Rp1TWkVOJ\nYZO/X7ZMeMRpykaNooih/L6w9YkrB9n8mRNwSgbHOLZbOqJf0JDfFksCgYEAwnEh\np1azZymZkAqODTzOy2TJtQ11H9HqE7++zOp26y3BOnME7kplAZr1QpTVcpUU2ts6\noFHp+DeB/4RxcM9/Xiu/tk6NftAHujVrMishZ2Rs5E+axTw+LjTdZFg2z9sFyPFl\nsDHGd05bv1cX62SzSndUPNipKtvFEZKwNXm6cAECgYEAwne8ardG0RW9nL2bwtj3\nDsv7TdSZdY1D7ffvFkWFqBOa1MgA1d+gU96MdPwiI7JC2jiLA9bmGFAzlvR00IUK\n14azvg6H3tC2URwyweSvZytf30vz5++cUQk1a5hgJaurNiIjajQiCkxMMwUH9abX\nCAFyPUe3ew+RCWHv/dmMLEkCgYEAoJGcIPxQGpkX3wNYW0Yj34LTr1f1qNlIXBa0\nEbRtj7ixIPtqzv1QfArjDqCpw32pQzJXL511gS0VhVRx+Z7gp3upTXuBDX/tYbBL\nXZqQczlTUxcJ0Gb3UmEFkp/mY6+TD2WJe/8ezdc/nLrnXdRC2vO/9J9W07W4/9IL\nAZ4MgAECgYEAh+BzzsPI+GDp7yEOrCpVJRFS+Q84oKmAGZ0pHlK9rCke95pS+ZxZ\nPADU0Gz+pqrN87btZg3BNZc1lAvW1U1SBg45kKsty7VQsgIMeWrM6zf8QQg6HUqG\niJUffEssW5xl+SvD4OBKE9qYuM9P5UqWKyE1uWg1IkXQlJPNw9S5tHo=\n-----END RSA PRIVATE KEY-----\n"
-    }
-  ],
-
-  "applications": [
-    {
-      "owner": "admin",
-      "name": "app-example",
-      "displayName": "FastAPI Example App",
-      "logo": "",
-      "homepageUrl": "http://localhost:8080",
-      "description": "casbin-fastapi-decorator-casdoor example",
-      "organization": "example-org",
-      "cert": "cert-example",
-      "enablePassword": true,
-      "enableSignUp": false,
-      "enableSignIn": true,
-      "grantTypes": ["authorization_code"],
-      "clientId": "example-client-id",
-      "clientSecret": "example-client-secret",
-      "redirectUris": ["http://localhost:8080/callback"],
-      "tokenFormat": "JWT",
-      "expireInHours": 168,
-      "refreshExpireInHours": 168
-    }
-  ],
-
-  "users": [
+  "adapters": [
     {
       "owner": "example-org",
-      "name": "alice",
-      "displayName": "Alice (admin)",
-      "email": "alice@example.com",
-      "password": "alice123",
-      "type": "normal-user",
-      "score": 0,
-      "isAdmin": false,
-      "isForbidden": false,
-      "isDeleted": false,
-      "signupApplication": "app-example"
-    },
-    {
-      "owner": "example-org",
-      "name": "bob",
-      "displayName": "Bob (viewer)",
-      "email": "bob@example.com",
-      "password": "bob123",
-      "type": "normal-user",
-      "score": 0,
-      "isAdmin": false,
-      "isForbidden": false,
-      "isDeleted": false,
-      "signupApplication": "app-example"
+      "name": "adapter-example",
+      "displayName": "Example Adapter",
+      "databaseType": "mysql",
+      "host": "localhost",
+      "port": 3306,
+      "user": "root",
+      "password": "123456",
+      "database": "casdoor",
+      "table": "casbin_rule"
     }
   ],
-
   "models": [
     {
       "owner": "example-org",
@@ -89,18 +35,16 @@
       "modelText": "[request_definition]\nr = sub, obj, act\n\n[policy_definition]\np = sub, obj, act\n\n[policy_effect]\ne = some(where (p.eft == allow))\n\n[matchers]\nm = r.sub == p.sub && r.obj == p.obj && r.act == p.act"
     }
   ],
-
   "enforcers": [
     {
       "owner": "example-org",
       "name": "enforcer-example",
       "displayName": "Example Enforcer",
       "model": "example-org/model-acl",
-      "adapter": "",
+      "adapter": "example-org/adapter-example",
       "isEnabled": true
     }
   ],
-
   "permissions": [
     {
       "owner": "example-org",
@@ -113,35 +57,7 @@
       "effect": "Allow",
       "isEnabled": true,
       "model": "example-org/model-acl",
-      "adapter": "",
-      "resourceType": "Custom"
-    },
-    {
-      "owner": "example-org",
-      "name": "alice-articles-write",
-      "displayName": "Alice — write articles",
-      "users": ["example-org/alice"],
-      "roles": [],
-      "resources": ["articles"],
-      "actions": ["write"],
-      "effect": "Allow",
-      "isEnabled": true,
-      "model": "example-org/model-acl",
-      "adapter": "",
-      "resourceType": "Custom"
-    },
-    {
-      "owner": "example-org",
-      "name": "bob-articles-read",
-      "displayName": "Bob — read articles",
-      "users": ["example-org/bob"],
-      "roles": [],
-      "resources": ["articles"],
-      "actions": ["read"],
-      "effect": "Allow",
-      "isEnabled": true,
-      "model": "example-org/model-acl",
-      "adapter": "",
+      "adapter": "example-org/adapter-example",
       "resourceType": "Custom"
     }
   ]

--- a/examples/core-casdoor/src/main.py
+++ b/examples/core-casdoor/src/main.py
@@ -1,15 +1,14 @@
 """Example: casbin-fastapi-decorator with Casdoor OAuth2 + remote enforcement."""
 from typing import Annotated
-from urllib.parse import urlencode
 
-from authz import _APP, _CLIENT_ID, _ENDPOINT, _ORG, casdoor, guard
+from authz import casdoor, guard
 from casdoor import AsyncCasdoorSDK
 from fastapi import Depends, FastAPI
 from model import ArticleCreateSchema, ArticleSchema, Permission, Resource
 
 app = FastAPI(title="Core + Casdoor Example")
 
-# Register GET /callback and POST /logout provided by the Casdoor integration.
+# Register GET /login, GET /callback and POST /logout provided by the integration.
 app.include_router(casdoor.router)
 
 # ---------------------------------------------------------------------------
@@ -28,23 +27,10 @@ MOCK_DB: list[ArticleSchema] = [
 
 @app.get("/")
 async def index() -> dict:
-    """Return the Casdoor login URL so the user knows where to start."""
-    params = urlencode(
-        {
-            "client_id": _CLIENT_ID,
-            "response_type": "code",
-            "redirect_uri": "http://localhost:8080/callback",
-            "scope": "read",
-            "state": "example",
-        }
-    )
-    login_url = (
-        f"{_ENDPOINT}/login/oauth/authorize?"
-        f"organizationName={_ORG}&applicationName={_APP}&{params}"
-    )
+    """Return a welcome message with a link to start the OAuth2 flow."""
     return {
         "message": "Log in via Casdoor to access protected endpoints.",
-        "login_url": login_url,
+        "login_url": "/login",
         "users": {
             "alice": {"password": "alice123", "can": ["read", "write"]},
             "bob": {"password": "bob123", "can": ["read"]},

--- a/packages/casbin-fastapi-decorator-casdoor/README.md
+++ b/packages/casbin-fastapi-decorator-casdoor/README.md
@@ -30,7 +30,7 @@ casdoor = CasdoorIntegration(
 )
 
 app = FastAPI()
-app.include_router(casdoor.router)   # GET /callback, POST /logout
+app.include_router(casdoor.router)   # GET /login, GET /callback, POST /logout
 guard = casdoor.create_guard()
 
 @app.get("/protected")
@@ -118,6 +118,7 @@ Main facade. Accepts all Casdoor SDK parameters plus:
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `target` | required | :class:`CasdoorEnforceTarget` — which Casdoor API identifier to use |
+| `state_manager` | `CookieStateManager()` | OAuth `state` issuance/verification strategy |
 | `access_token_cookie` | `"access_token"` | Cookie name for the access token |
 | `refresh_token_cookie` | `"refresh_token"` | Cookie name for the refresh token |
 | `redirect_after_login` | `"/"` | Path or absolute URL to redirect after OAuth2 callback. Relative (`"/"`) stays on the same host; absolute (`"https://app.example.com/"`) redirects to another host. |
@@ -127,7 +128,7 @@ Main facade. Accepts all Casdoor SDK parameters plus:
 | `cookie_domain` | `None` | `Domain` attribute. Use `".example.com"` to share cookies across subdomains (e.g. `*.my-site.ru`) |
 | `cookie_path` | `"/"` | `Path` attribute of the cookie |
 | `cookie_max_age` | `None` | `Max-Age` in seconds; `None` = session cookie |
-| `router_prefix` | `""` | URL prefix for `/callback` and `/logout` |
+| `router_prefix` | `""` | URL prefix for `/login`, `/callback` and `/logout` |
 
 ### `CasdoorUserProvider`
 
@@ -151,13 +152,15 @@ FastAPI dependency that returns a shared `CasdoorEnforcer`.
 
 Factory that returns a `fastapi.APIRouter` with two endpoints:
 
-- `GET {prefix}/callback` — exchanges OAuth2 code for tokens, sets cookies
+- `GET {prefix}/login` — issues OAuth2 state and redirects to Casdoor
+- `GET {prefix}/callback` — validates state, exchanges OAuth2 code for tokens, sets cookies
 - `POST {prefix}/logout` — clears authentication cookies
 
-> **Security note — OAuth2 state / CSRF.**
-> The `state` query parameter sent by Casdoor is accepted but **not validated**.
-> This is an intentional trade-off for stateless deployments.
-> If your threat model requires CSRF protection, implement state validation
-> yourself: generate a nonce before redirecting to Casdoor, store it in a
-> short-lived cookie or session, and verify it in the callback handler before
-> exchanging the code.
+Default `state` protection is provided by `CookieStateManager`:
+
+- cookie name: `casdoor_oauth_state`
+- `HttpOnly=True`, `Secure=True`, `SameSite=lax`
+- `Max-Age=300`
+
+You can override state handling using `CasdoorStateManager` protocol
+implementation (e.g. Redis/session-backed storage).

--- a/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/__init__.py
+++ b/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/__init__.py
@@ -18,8 +18,8 @@ __all__ = [
     "CasdoorEnforcer",
     "CasdoorEnforcerProvider",
     "CasdoorIntegration",
-    "CasdoorUserProvider",
     "CasdoorStateManager",
+    "CasdoorUserProvider",
     "CookieStateManager",
     "make_casdoor_router",
 ]

--- a/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/__init__.py
+++ b/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/__init__.py
@@ -7,7 +7,11 @@ from casbin_fastapi_decorator_casdoor._enforcer import (
 )
 from casbin_fastapi_decorator_casdoor._integration import CasdoorIntegration
 from casbin_fastapi_decorator_casdoor._provider import CasdoorUserProvider
-from casbin_fastapi_decorator_casdoor._router import make_casdoor_router
+from casbin_fastapi_decorator_casdoor._router import (
+    CasdoorStateManager,
+    CookieStateManager,
+    make_casdoor_router,
+)
 
 __all__ = [
     "CasdoorEnforceTarget",
@@ -15,5 +19,7 @@ __all__ = [
     "CasdoorEnforcerProvider",
     "CasdoorIntegration",
     "CasdoorUserProvider",
+    "CasdoorStateManager",
+    "CookieStateManager",
     "make_casdoor_router",
 ]

--- a/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_integration.py
+++ b/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_integration.py
@@ -146,8 +146,7 @@ class CasdoorIntegration:
     @property
     def router(self) -> APIRouter:
         """
-        :class:`APIRouter` with ``GET /login``, ``GET /callback`` and
-        ``POST /logout``.
+        :class:`APIRouter` with ``/login``, ``/callback`` and ``/logout``.
 
         Include it in your FastAPI app::
 

--- a/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_integration.py
+++ b/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_integration.py
@@ -11,7 +11,10 @@ from casbin_fastapi_decorator_casdoor._enforcer import (
     CasdoorEnforceTarget,
 )
 from casbin_fastapi_decorator_casdoor._provider import CasdoorUserProvider
-from casbin_fastapi_decorator_casdoor._router import make_casdoor_router
+from casbin_fastapi_decorator_casdoor._router import (
+    CasdoorStateManager,
+    make_casdoor_router,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -54,7 +57,8 @@ class CasdoorIntegration:
             ...
 
     For advanced customisation (custom ``user_factory``, different enforce
-    target per route, etc.) compose the components manually::
+    target per route, state handling strategy, etc.) compose the components
+    manually::
 
         sdk = AsyncCasdoorSDK(...)
         target = CasdoorEnforceTarget(permission_id="my_org/can_read")
@@ -80,6 +84,7 @@ class CasdoorIntegration:
         org_name: str,
         application_name: str,
         target: CasdoorEnforceTarget,
+        state_manager: CasdoorStateManager | None = None,
         access_token_cookie: str = "access_token",
         refresh_token_cookie: str = "refresh_token",
         redirect_after_login: str = "/",
@@ -110,6 +115,7 @@ class CasdoorIntegration:
         )
         self._router = make_casdoor_router(
             self._sdk,
+            state_manager=state_manager,
             access_token_cookie=access_token_cookie,
             refresh_token_cookie=refresh_token_cookie,
             redirect_after_login=redirect_after_login,
@@ -140,7 +146,8 @@ class CasdoorIntegration:
     @property
     def router(self) -> APIRouter:
         """
-        :class:`APIRouter` with ``GET /callback`` and ``POST /logout``.
+        :class:`APIRouter` with ``GET /login``, ``GET /callback`` and
+        ``POST /logout``.
 
         Include it in your FastAPI app::
 

--- a/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_router.py
+++ b/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_router.py
@@ -34,7 +34,7 @@ class CasdoorStateManager(Protocol):
 class CookieStateManager:
     """Cookie-backed default implementation for OAuth ``state``."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         cookie_name: str = "casdoor_oauth_state",
@@ -139,6 +139,9 @@ def make_casdoor_router(  # noqa: PLR0913
     """
     router = APIRouter(prefix=prefix)
     state_manager_impl = state_manager or CookieStateManager(
+        cookie_secure=cookie_secure,
+        cookie_httponly=cookie_httponly,
+        cookie_samesite=cookie_samesite,
         cookie_domain=cookie_domain,
         cookie_path=cookie_path,
     )
@@ -153,25 +156,23 @@ def make_casdoor_router(  # noqa: PLR0913
 
     @router.get("/login")
     async def login(request: Request) -> RedirectResponse:
-        response = RedirectResponse(url=redirect_after_login)
-        state = await state_manager_impl.issue(response)
+        tmp = Response()
+        state = await state_manager_impl.issue(tmp)
         auth_url = await _build_auth_url(
             sdk,
             redirect_uri=str(request.url_for("callback")),
             state=state,
         )
-        response.headers["location"] = auth_url
+        response = RedirectResponse(url=auth_url, status_code=HTTP_302_FOUND)
+        response.raw_headers.extend(tmp.raw_headers)
         return response
 
     @router.get("/callback")
     async def callback(
         request: Request,
         code: str,
-        state: str | None = None,
+        state: str,
     ) -> RedirectResponse:
-        if not state:
-            raise HTTPException(status_code=HTTP_400_BAD_REQUEST)
-
         response = RedirectResponse(
             url=redirect_after_login,
             status_code=HTTP_302_FOUND,
@@ -182,10 +183,7 @@ def make_casdoor_router(  # noqa: PLR0913
             state=state,
         )
         if not is_valid_state:
-            return Response(
-                status_code=HTTP_401_UNAUTHORIZED,
-                headers=dict(response.headers),
-            )
+            raise HTTPException(status_code=HTTP_400_BAD_REQUEST)
 
         tokens = await sdk.get_oauth_token(code=code)
         if not tokens.get("access_token") or not tokens.get("refresh_token"):

--- a/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_router.py
+++ b/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_router.py
@@ -1,18 +1,98 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from secrets import token_urlsafe
+from typing import TYPE_CHECKING, Literal, Protocol
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import RedirectResponse, Response
-from starlette.status import HTTP_302_FOUND, HTTP_401_UNAUTHORIZED
+from starlette.status import (
+    HTTP_302_FOUND,
+    HTTP_400_BAD_REQUEST,
+    HTTP_401_UNAUTHORIZED,
+)
 
 if TYPE_CHECKING:
     from casdoor import AsyncCasdoorSDK
 
 
+class CasdoorStateManager(Protocol):
+    """Protocol for OAuth ``state`` issuance and verification."""
+
+    async def issue(self, response: Response) -> str:
+        """Issue and persist state for a login attempt."""
+
+    async def verify(
+        self,
+        request: Request,
+        response: Response,
+        state: str,
+    ) -> bool:
+        """Validate the callback ``state`` and clear one-time storage."""
+
+
+class CookieStateManager:
+    """Cookie-backed default implementation for OAuth ``state``."""
+
+    def __init__(
+        self,
+        *,
+        cookie_name: str = "casdoor_oauth_state",
+        cookie_secure: bool = True,
+        cookie_httponly: bool = True,
+        cookie_samesite: Literal["lax", "strict", "none"] = "lax",
+        cookie_domain: str | None = None,
+        cookie_path: str = "/",
+        cookie_max_age: int = 300,
+    ) -> None:
+        self._cookie_name = cookie_name
+        self._cookie_kwargs = {
+            "secure": cookie_secure,
+            "httponly": cookie_httponly,
+            "samesite": cookie_samesite,
+            "domain": cookie_domain,
+            "path": cookie_path,
+        }
+        self._cookie_max_age = cookie_max_age
+
+    async def issue(self, response: Response) -> str:
+        state = token_urlsafe(32)
+        response.set_cookie(
+            key=self._cookie_name,
+            value=state,
+            max_age=self._cookie_max_age,
+            **self._cookie_kwargs,
+        )
+        return state
+
+    async def verify(
+        self,
+        request: Request,
+        response: Response,
+        state: str,
+    ) -> bool:
+        expected_state = request.cookies.get(self._cookie_name)
+        response.delete_cookie(key=self._cookie_name, **self._cookie_kwargs)
+        return bool(expected_state) and expected_state == state
+
+
+async def _build_auth_url(
+    sdk: AsyncCasdoorSDK,
+    *,
+    redirect_uri: str,
+    state: str,
+) -> str:
+    auth_url = await sdk.get_auth_link(redirect_uri=redirect_uri)
+    parsed = urlparse(auth_url)
+    query_params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query_params["state"] = state
+    return urlunparse(parsed._replace(query=urlencode(query_params)))
+
+
 def make_casdoor_router(  # noqa: PLR0913
     sdk: AsyncCasdoorSDK,
     *,
+    state_manager: CasdoorStateManager | None = None,
     access_token_cookie: str = "access_token",
     refresh_token_cookie: str = "refresh_token",
     redirect_after_login: str = "/",
@@ -29,11 +109,14 @@ def make_casdoor_router(  # noqa: PLR0913
 
     Routes:
 
+    - ``GET {prefix}/login`` — Start OAuth2 login and redirect to Casdoor.
     - ``GET {prefix}/callback`` — Exchange OAuth2 code for tokens, set cookies.
     - ``POST {prefix}/logout`` — Clear authentication cookies.
 
     Args:
         sdk: Configured :class:`AsyncCasdoorSDK` instance.
+        state_manager: OAuth ``state`` manager. Defaults to
+            :class:`CookieStateManager`.
         access_token_cookie: Name of the access-token cookie.
         refresh_token_cookie: Name of the refresh-token cookie.
         redirect_after_login: Path or absolute URL to redirect to after
@@ -55,6 +138,10 @@ def make_casdoor_router(  # noqa: PLR0913
 
     """
     router = APIRouter(prefix=prefix)
+    state_manager_impl = state_manager or CookieStateManager(
+        cookie_domain=cookie_domain,
+        cookie_path=cookie_path,
+    )
 
     _cookie_kwargs = {
         "secure": cookie_secure,
@@ -64,16 +151,46 @@ def make_casdoor_router(  # noqa: PLR0913
         "path": cookie_path,
     }
 
+    @router.get("/login")
+    async def login(request: Request) -> RedirectResponse:
+        response = RedirectResponse(url=redirect_after_login)
+        state = await state_manager_impl.issue(response)
+        auth_url = await _build_auth_url(
+            sdk,
+            redirect_uri=str(request.url_for("callback")),
+            state=state,
+        )
+        response.headers["location"] = auth_url
+        return response
+
     @router.get("/callback")
-    async def callback(code: str, state: str = "") -> RedirectResponse:  # noqa: ARG001
-        tokens = await sdk.get_oauth_token(code=code)
-        if not tokens.get("access_token") or not tokens.get("refresh_token"):
-            raise HTTPException(status_code=HTTP_401_UNAUTHORIZED)
+    async def callback(
+        request: Request,
+        code: str,
+        state: str | None = None,
+    ) -> RedirectResponse:
+        if not state:
+            raise HTTPException(status_code=HTTP_400_BAD_REQUEST)
 
         response = RedirectResponse(
             url=redirect_after_login,
             status_code=HTTP_302_FOUND,
         )
+        is_valid_state = await state_manager_impl.verify(
+            request=request,
+            response=response,
+            state=state,
+        )
+        if not is_valid_state:
+            return Response(
+                status_code=HTTP_401_UNAUTHORIZED,
+                headers=dict(response.headers),
+            )
+
+        tokens = await sdk.get_oauth_token(code=code)
+        if not tokens.get("access_token") or not tokens.get("refresh_token"):
+            raise HTTPException(status_code=HTTP_401_UNAUTHORIZED)
+
         for key, value in (
             (access_token_cookie, tokens["access_token"]),
             (refresh_token_cookie, tokens["refresh_token"]),

--- a/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_router.py
+++ b/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from hmac import compare_digest
 from secrets import token_urlsafe
 from typing import TYPE_CHECKING, Literal, Protocol
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
@@ -73,7 +74,7 @@ class CookieStateManager:
     ) -> bool:
         expected_state = request.cookies.get(self._cookie_name)
         response.delete_cookie(key=self._cookie_name, **self._cookie_kwargs)
-        return bool(expected_state) and expected_state == state
+        return bool(expected_state) and compare_digest(expected_state, state)
 
 
 async def _build_auth_url(

--- a/packages/casbin-fastapi-decorator-casdoor/tests/integration/router/act.py
+++ b/packages/casbin-fastapi-decorator-casdoor/tests/integration/router/act.py
@@ -1,4 +1,4 @@
-"""Integration tests — make_casdoor_router endpoints (callback + logout)."""
+"""Integration tests — make_casdoor_router endpoints."""
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
@@ -15,6 +15,12 @@ REFRESH_TOKEN = "header.payload.refresh"
 
 def _make_sdk(tokens: dict | None = None) -> MagicMock:
     sdk = MagicMock()
+    sdk.get_auth_link = AsyncMock(
+        return_value=(
+            "http://casdoor.example/login/oauth/authorize"
+            "?client_id=test&response_type=code"
+        )
+    )
     sdk.get_oauth_token = AsyncMock(
         return_value=(
             {"access_token": ACCESS_TOKEN, "refresh_token": REFRESH_TOKEN}
@@ -25,27 +31,51 @@ def _make_sdk(tokens: dict | None = None) -> MagicMock:
     return sdk
 
 
-def _make_app(sdk: MagicMock, **router_kwargs) -> FastAPI:  # type: ignore[return]
+def _make_app(
+    sdk: MagicMock, **router_kwargs
+) -> FastAPI:  # type: ignore[return]
     app = FastAPI()
     router = make_casdoor_router(sdk, **router_kwargs)
     app.include_router(router)
     return app
 
 
-# ---------------------------------------------------------------------------
-# GET /callback — happy path
-# ---------------------------------------------------------------------------
+async def _start_login(client: AsyncClient) -> tuple[str, str]:
+    login_resp = await client.get("/login", follow_redirects=False)
+    state_cookie = client.cookies.get("casdoor_oauth_state")
+    assert state_cookie is not None
+    assert login_resp.status_code == 302
+    assert "state=" in login_resp.headers["location"]
+    return state_cookie, login_resp.headers["location"]
+
+
+@pytest.mark.integration
+async def test_login_sets_state_cookie_and_redirects_to_casdoor() -> None:
+    app = _make_app(_make_sdk(), cookie_secure=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        state_cookie, location = await _start_login(client)
+    assert state_cookie
+    assert location.startswith("http://casdoor.example/login/oauth/authorize")
 
 
 @pytest.mark.integration
 async def test_callback_redirects_after_successful_token_exchange() -> None:
-    app = _make_app(_make_sdk(), redirect_after_login="/dashboard")
+    app = _make_app(
+        _make_sdk(),
+        redirect_after_login="/dashboard",
+        cookie_secure=False,
+    )
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test",
         follow_redirects=False,
     ) as client:
-        resp = await client.get("/callback", params={"code": "auth-code"})
+        state_cookie, _ = await _start_login(client)
+        resp = await client.get(
+            "/callback", params={"code": "auth-code", "state": state_cookie}
+        )
     assert resp.status_code == 302
     assert resp.headers["location"] == "/dashboard"
 
@@ -58,7 +88,10 @@ async def test_callback_sets_access_token_cookie() -> None:
         base_url="http://test",
         follow_redirects=False,
     ) as client:
-        resp = await client.get("/callback", params={"code": "auth-code"})
+        state_cookie, _ = await _start_login(client)
+        resp = await client.get(
+            "/callback", params={"code": "auth-code", "state": state_cookie}
+        )
     cookie_header = resp.headers.get("set-cookie", "")
     assert "access_token" in cookie_header
 
@@ -71,26 +104,13 @@ async def test_callback_sets_refresh_token_cookie() -> None:
         base_url="http://test",
         follow_redirects=False,
     ) as client:
-        resp = await client.get("/callback", params={"code": "auth-code"})
-    # RedirectResponse may set multiple Set-Cookie headers; check raw headers
+        state_cookie, _ = await _start_login(client)
+        resp = await client.get(
+            "/callback", params={"code": "auth-code", "state": state_cookie}
+        )
     all_headers = resp.headers.multi_items()
     set_cookies = [v for k, v in all_headers if k.lower() == "set-cookie"]
     assert any("refresh_token" in h for h in set_cookies)
-
-
-@pytest.mark.integration
-async def test_callback_accepts_state_param_without_error() -> None:
-    """state is accepted but not validated — must not cause 422."""
-    app = _make_app(_make_sdk(), cookie_secure=False)
-    async with AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test",
-        follow_redirects=False,
-    ) as client:
-        resp = await client.get(
-            "/callback", params={"code": "auth-code", "state": "some-nonce"}
-        )
-    assert resp.status_code == 302
 
 
 @pytest.mark.integration
@@ -107,60 +127,89 @@ async def test_callback_custom_cookie_names() -> None:
         base_url="http://test",
         follow_redirects=False,
     ) as client:
-        resp = await client.get("/callback", params={"code": "auth-code"})
+        state_cookie, _ = await _start_login(client)
+        resp = await client.get(
+            "/callback", params={"code": "auth-code", "state": state_cookie}
+        )
     all_headers = resp.headers.multi_items()
     set_cookies = [v for k, v in all_headers if k.lower() == "set-cookie"]
     assert any("my_access" in h for h in set_cookies)
     assert any("my_refresh" in h for h in set_cookies)
 
 
-# ---------------------------------------------------------------------------
-# GET /callback — error cases
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.integration
-async def test_callback_returns_401_when_access_token_missing() -> None:
-    sdk = _make_sdk(tokens={"refresh_token": REFRESH_TOKEN})
-    app = _make_app(sdk)
+async def test_callback_returns_400_when_state_missing() -> None:
+    app = _make_app(_make_sdk(), cookie_secure=False)
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test",
         follow_redirects=False,
     ) as client:
         resp = await client.get("/callback", params={"code": "auth-code"})
+    assert resp.status_code == 400
+
+
+@pytest.mark.integration
+async def test_callback_returns_401_when_state_is_invalid() -> None:
+    app = _make_app(_make_sdk(), cookie_secure=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        await _start_login(client)
+        resp = await client.get(
+            "/callback", params={"code": "auth-code", "state": "invalid-state"}
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.integration
+async def test_callback_returns_401_when_access_token_missing() -> None:
+    sdk = _make_sdk(tokens={"refresh_token": REFRESH_TOKEN})
+    app = _make_app(sdk, cookie_secure=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        state_cookie, _ = await _start_login(client)
+        resp = await client.get(
+            "/callback", params={"code": "auth-code", "state": state_cookie}
+        )
     assert resp.status_code == 401
 
 
 @pytest.mark.integration
 async def test_callback_returns_401_when_refresh_token_missing() -> None:
     sdk = _make_sdk(tokens={"access_token": ACCESS_TOKEN})
-    app = _make_app(sdk)
+    app = _make_app(sdk, cookie_secure=False)
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test",
         follow_redirects=False,
     ) as client:
-        resp = await client.get("/callback", params={"code": "auth-code"})
+        state_cookie, _ = await _start_login(client)
+        resp = await client.get(
+            "/callback", params={"code": "auth-code", "state": state_cookie}
+        )
     assert resp.status_code == 401
 
 
 @pytest.mark.integration
 async def test_callback_returns_401_when_tokens_dict_empty() -> None:
     sdk = _make_sdk(tokens={})
-    app = _make_app(sdk)
+    app = _make_app(sdk, cookie_secure=False)
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test",
         follow_redirects=False,
     ) as client:
-        resp = await client.get("/callback", params={"code": "auth-code"})
+        state_cookie, _ = await _start_login(client)
+        resp = await client.get(
+            "/callback", params={"code": "auth-code", "state": state_cookie}
+        )
     assert resp.status_code == 401
-
-
-# ---------------------------------------------------------------------------
-# POST /logout
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -216,11 +265,6 @@ async def test_logout_with_custom_cookie_names() -> None:
     assert any("my_refresh" in h for h in set_cookies)
 
 
-# ---------------------------------------------------------------------------
-# Router prefix
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.integration
 async def test_router_prefix_applied() -> None:
     sdk = _make_sdk()
@@ -230,7 +274,15 @@ async def test_router_prefix_applied() -> None:
         base_url="http://test",
         follow_redirects=False,
     ) as client:
-        resp = await client.get("/auth/callback", params={"code": "auth-code"})
+        login_resp = await client.get("/auth/login")
+        state_cookie = client.cookies.get("casdoor_oauth_state")
+        assert state_cookie is not None
+        resp = await client.get(
+            "/auth/callback",
+            params={"code": "auth-code", "state": state_cookie},
+            follow_redirects=False,
+        )
+    assert login_resp.status_code == 302
     assert resp.status_code == 302
 
 

--- a/packages/casbin-fastapi-decorator-casdoor/tests/integration/router/act.py
+++ b/packages/casbin-fastapi-decorator-casdoor/tests/integration/router/act.py
@@ -138,7 +138,7 @@ async def test_callback_custom_cookie_names() -> None:
 
 
 @pytest.mark.integration
-async def test_callback_returns_400_when_state_missing() -> None:
+async def test_callback_returns_422_when_state_missing() -> None:
     app = _make_app(_make_sdk(), cookie_secure=False)
     async with AsyncClient(
         transport=ASGITransport(app=app),
@@ -146,11 +146,11 @@ async def test_callback_returns_400_when_state_missing() -> None:
         follow_redirects=False,
     ) as client:
         resp = await client.get("/callback", params={"code": "auth-code"})
-    assert resp.status_code == 400
+    assert resp.status_code == 422
 
 
 @pytest.mark.integration
-async def test_callback_returns_401_when_state_is_invalid() -> None:
+async def test_callback_returns_400_when_state_is_invalid() -> None:
     app = _make_app(_make_sdk(), cookie_secure=False)
     async with AsyncClient(
         transport=ASGITransport(app=app),
@@ -161,7 +161,7 @@ async def test_callback_returns_401_when_state_is_invalid() -> None:
         resp = await client.get(
             "/callback", params={"code": "auth-code", "state": "invalid-state"}
         )
-    assert resp.status_code == 401
+    assert resp.status_code == 400
 
 
 @pytest.mark.integration

--- a/packages/casbin-fastapi-decorator-casdoor/tests/unit/integration_facade/act.py
+++ b/packages/casbin-fastapi-decorator-casdoor/tests/unit/integration_facade/act.py
@@ -76,6 +76,7 @@ def test_router_property_returns_api_router() -> None:
 def test_router_has_callback_and_logout_routes() -> None:
     integration = _make_integration()
     paths = {route.path for route in integration.router.routes}  # type: ignore[attr-defined]
+    assert "/login" in paths
     assert "/callback" in paths
     assert "/logout" in paths
 
@@ -121,5 +122,6 @@ def test_router_prefix_applied_to_routes() -> None:
     # Route paths may include the prefix depending on FastAPI version;
     # verify both callback and logout routes exist under the prefix.
     paths = {route.path for route in integration.router.routes}  # type: ignore[attr-defined]
+    assert any("login" in p for p in paths)
     assert any("callback" in p for p in paths)
     assert any("logout" in p for p in paths)

--- a/taskfile.dist.yaml
+++ b/taskfile.dist.yaml
@@ -98,10 +98,11 @@ tasks:
     requires:
       vars: [VERSION]
     cmds:
-      - uv version {{.VERSION}}
-      - uv version {{.VERSION}} --package casbin-fastapi-decorator-jwt
-      - uv version {{.VERSION}} --package casbin-fastapi-decorator-db
-      - uv version {{.VERSION}} --package casbin-fastapi-decorator-casdoor
+      - uv version {{.VERSION}} --frozen
+      - uv version {{.VERSION}} --package casbin-fastapi-decorator-jwt --frozen
+      - uv version {{.VERSION}} --package casbin-fastapi-decorator-db --frozen
+      - uv version {{.VERSION}} --package casbin-fastapi-decorator-casdoor --frozen
+      - uv lock
 
   release:changelog:
     desc: Generate CHANGELOG.md (requires TAG=vX.Y.Z)
@@ -120,6 +121,7 @@ tasks:
                 packages/casbin-fastapi-decorator-jwt/pyproject.toml \
                 packages/casbin-fastapi-decorator-db/pyproject.toml \
                 packages/casbin-fastapi-decorator-casdoor/pyproject.toml \
+                uv.lock \
                 CHANGELOG.md
         git commit -m "chore(release): {{.TAG}}"
         git tag -a "{{.TAG}}" -m "Release {{.TAG}}"

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "casbin-fastapi-decorator"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "casbin" },
@@ -332,7 +332,7 @@ test = [
 
 [[package]]
 name = "casbin-fastapi-decorator-casdoor"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "packages/casbin-fastapi-decorator-casdoor" }
 dependencies = [
     { name = "casbin-fastapi-decorator" },
@@ -365,7 +365,7 @@ test = [
 
 [[package]]
 name = "casbin-fastapi-decorator-db"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "packages/casbin-fastapi-decorator-db" }
 dependencies = [
     { name = "casbin-fastapi-decorator" },
@@ -404,7 +404,7 @@ test = [
 
 [[package]]
 name = "casbin-fastapi-decorator-jwt"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "packages/casbin-fastapi-decorator-jwt" }
 dependencies = [
     { name = "casbin-fastapi-decorator" },


### PR DESCRIPTION
Adds CSRF protection to the Casdoor OAuth2 flow via a pluggable state manager and a new \`/login\` endpoint.

**Changes:**

- Added `CasdoorStateManager` protocol and `CookieStateManager` default implementation — issues a signed nonce cookie on `/login` and verifies it on `/callback` using `hmac.compare_digest`.
- Added `GET /login` endpoint that issues the state nonce and redirects to Casdoor; `GET /callback` now requires a valid `state` parameter (returns 400 on mismatch).
- `make_casdoor_router` and `CasdoorIntegration` accept an optional `state_manager` to allow custom backends (e.g. Redis, session).
- `CasdoorStateManager` and `CookieStateManager` are exported from the public API.
- Updated README and example docs to reflect the new `/login` route and state protection behavior.
- Updated tests to cover the full login→callback flow, invalid state (400), and missing state (422).