### PR TITLE
fix(Casdoor): Add token revocation and user profile endpoint to Casdoor router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Features
+
+- **Casdoor**: add Casdoor-side token revocation in `/logout` endpoint
+- **Casdoor**: add `GET /me` endpoint to retrieve current user's profile
+
 ## [1.1.0] - 2026-04-10
 ### Features
 

--- a/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_router.py
+++ b/packages/casbin-fastapi-decorator-casdoor/src/casbin_fastapi_decorator_casdoor/_router.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from hmac import compare_digest
 from secrets import token_urlsafe
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-from fastapi import APIRouter, HTTPException, Request
+import jwt
+from fastapi import APIRouter, HTTPException, Request, Security
 from fastapi.responses import RedirectResponse, Response
+from fastapi.security import APIKeyCookie
 from starlette.status import (
     HTTP_302_FOUND,
     HTTP_400_BAD_REQUEST,
@@ -111,8 +113,9 @@ def make_casdoor_router(  # noqa: PLR0913
     Routes:
 
     - ``GET {prefix}/login`` — Start OAuth2 login and redirect to Casdoor.
-    - ``GET {prefix}/callback`` — Exchange OAuth2 code for tokens, set cookies.
-    - ``POST {prefix}/logout`` — Clear authentication cookies.
+    - ``GET {prefix}/callback`` — Exchange OAuth2 code for tokens.
+    - ``POST {prefix}/logout`` — Revoke tokens and clear cookies.
+    - ``GET {prefix}/me`` — Retrieve current user's profile.
 
     Args:
         sdk: Configured :class:`AsyncCasdoorSDK` instance.
@@ -154,6 +157,13 @@ def make_casdoor_router(  # noqa: PLR0913
         "domain": cookie_domain,
         "path": cookie_path,
     }
+
+    _access_cookie_scheme = APIKeyCookie(
+        name=access_token_cookie, auto_error=False
+    )
+    _refresh_cookie_scheme = APIKeyCookie(
+        name=refresh_token_cookie, auto_error=False
+    )
 
     @router.get("/login")
     async def login(request: Request) -> RedirectResponse:
@@ -203,8 +213,27 @@ def make_casdoor_router(  # noqa: PLR0913
         return response
 
     @router.post("/logout")
-    async def logout(response: Response) -> None:
+    async def logout(
+        response: Response,
+        refresh_token: str | None = Security(_refresh_cookie_scheme),
+    ) -> None:
+        if refresh_token:
+            await sdk.oauth_token_revoke(refresh_token, "refresh_token")
         for key in (access_token_cookie, refresh_token_cookie):
             response.delete_cookie(key=key, **_cookie_kwargs)
+
+    @router.get("/me")
+    async def me(
+        access_token: str | None = Security(_access_cookie_scheme),
+    ) -> dict[str, Any]:
+        if access_token is None:
+            raise HTTPException(status_code=HTTP_401_UNAUTHORIZED)
+        try:
+            return sdk.parse_jwt_token(access_token)
+        except (ValueError, jwt.PyJWTError) as e:
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail=f"Invalid token: {e}",
+            ) from e
 
     return router

--- a/packages/casbin-fastapi-decorator-casdoor/tests/integration/router/act.py
+++ b/packages/casbin-fastapi-decorator-casdoor/tests/integration/router/act.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import jwt as pyjwt
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -28,6 +29,10 @@ def _make_sdk(tokens: dict | None = None) -> MagicMock:
             else tokens
         )
     )
+    sdk.parse_jwt_token = MagicMock(
+        return_value={"owner": "org", "name": "user1"}
+    )
+    sdk.oauth_token_revoke = AsyncMock()
     return sdk
 
 
@@ -295,3 +300,95 @@ async def test_callback_without_prefix_returns_404_when_prefix_set() -> None:
     ) as client:
         resp = await client.get("/callback", params={"code": "auth-code"})
     assert resp.status_code == 404
+
+
+@pytest.mark.integration
+async def test_logout_revokes_token_on_casdoor() -> None:
+    sdk = _make_sdk()
+    app = _make_app(sdk, cookie_secure=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        client.cookies.set("refresh_token", REFRESH_TOKEN)
+        resp = await client.post("/logout")
+    assert resp.status_code == 200
+    sdk.oauth_token_revoke.assert_called_once_with(REFRESH_TOKEN, "refresh_token")
+
+
+@pytest.mark.integration
+async def test_logout_without_refresh_token_does_not_call_revoke() -> None:
+    sdk = _make_sdk()
+    app = _make_app(sdk, cookie_secure=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/logout")
+    assert resp.status_code == 200
+    sdk.oauth_token_revoke.assert_not_called()
+
+
+@pytest.mark.integration
+async def test_me_returns_user_profile() -> None:
+    sdk = _make_sdk()
+    app = _make_app(sdk, cookie_secure=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        client.cookies.set("access_token", ACCESS_TOKEN)
+        resp = await client.get("/me")
+    assert resp.status_code == 200
+    assert resp.json() == {"owner": "org", "name": "user1"}
+
+
+@pytest.mark.integration
+async def test_me_returns_401_when_no_access_token() -> None:
+    sdk = _make_sdk()
+    app = _make_app(sdk, cookie_secure=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/me")
+    assert resp.status_code == 401
+
+
+@pytest.mark.integration
+async def test_me_returns_401_on_invalid_token() -> None:
+    sdk = _make_sdk()
+    sdk.parse_jwt_token.side_effect = pyjwt.PyJWTError("Invalid signature")
+    app = _make_app(sdk, cookie_secure=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        client.cookies.set("access_token", "invalid.token.here")
+        resp = await client.get("/me")
+    assert resp.status_code == 401
+
+
+@pytest.mark.integration
+async def test_me_with_custom_cookie_name() -> None:
+    sdk = _make_sdk()
+    app = _make_app(
+        sdk,
+        access_token_cookie="my_access",
+        cookie_secure=False,
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        client.cookies.set("my_access", ACCESS_TOKEN)
+        resp = await client.get("/me")
+    assert resp.status_code == 200
+    assert resp.json() == {"owner": "org", "name": "user1"}
+
+
+@pytest.mark.integration
+async def test_me_with_prefix() -> None:
+    sdk = _make_sdk()
+    app = _make_app(sdk, prefix="/auth", cookie_secure=False)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        client.cookies.set("access_token", ACCESS_TOKEN)
+        resp = await client.get("/auth/me")
+    assert resp.status_code == 200
+    assert resp.json() == {"owner": "org", "name": "user1"}


### PR DESCRIPTION
## Summary
This PR enhances the Casdoor authentication router by adding token revocation functionality to the logout endpoint and introducing a new `/me` endpoint to retrieve the current user's profile information.

## Key Changes

- **Token Revocation on Logout**: The `/logout` endpoint now revokes the refresh token on the Casdoor server before clearing cookies, ensuring proper server-side token invalidation
- **New `/me` Endpoint**: Added a `GET /me` endpoint that returns the current user's profile by parsing the access token JWT
- **Enhanced Security**: Implemented cookie-based authentication using FastAPI's `APIKeyCookie` security scheme for both access and refresh tokens
- **Error Handling**: Added proper JWT validation with appropriate 401 responses for missing or invalid tokens

## Implementation Details

- The logout endpoint now accepts an optional refresh token from cookies and calls `sdk.oauth_token_revoke()` if present
- The new `/me` endpoint uses `Security()` with `APIKeyCookie` to extract the access token from cookies
- JWT parsing errors (`jwt.PyJWTError` and `ValueError`) are caught and converted to 401 Unauthorized responses
- Both endpoints respect custom cookie names and router prefixes
- Added comprehensive integration tests covering success cases, error conditions, and custom configurations

https://claude.ai/code/session_01ALdnWYy4U7UCWryo572jUq