### PR TITLE
Document new GET /me endpoint for user profile retrieval

### DIFF
--- a/packages/casbin-fastapi-decorator-casdoor/README.md
+++ b/packages/casbin-fastapi-decorator-casdoor/README.md
@@ -157,6 +157,7 @@ Factory that returns a `fastapi.APIRouter` with these endpoints:
 - `POST {prefix}/logout` — calls Casdoor SSO logout
   (`/api/sso-logout?logoutAll=true`) when an access-token cookie is present,
   then clears authentication cookies
+- `GET {prefix}/me` — returns the current user's profile by parsing the JWT access token
 
 Default `state` protection is provided by `CookieStateManager`:
 


### PR DESCRIPTION
## Summary
Updated documentation to reflect a new endpoint that retrieves the current user's profile information from the JWT access token.

## Changes
- Added documentation for `GET {prefix}/me` endpoint that returns the current user's profile by parsing the JWT access token

## Details
This change documents an existing or newly added endpoint in the FastAPI router factory. The endpoint provides a convenient way for clients to retrieve the authenticated user's profile information without making additional calls to external services, by extracting and parsing the JWT access token that's already present in the request.

https://claude.ai/code/session_01Wu4dTu7mw5UrWxfyHwiR9i